### PR TITLE
Correct spelling of Eric Brooke (singular)

### DIFF
--- a/companies.html
+++ b/companies.html
@@ -7,7 +7,7 @@ title: "VanRuby - Local Companies"
   <div class="col-md-12">
 
     <h1>Companies</h1>
-    <p>Here is a list of companies that developers in or around Vancouver are working for. Kindly first put together from <a href="http://ca.linkedin.com/in/ericbrooke/" target="_blank">Eric Brookes</a>.</p>
+    <p>Here is a list of companies that developers in or around Vancouver are working for. Kindly first put together from <a href="http://ca.linkedin.com/in/ericbrooke/" target="_blank">Eric Brooke</a>.</p>
 
     <p>To be a part of these {{site.data.companies.size}} companies working with Ruby, modify the <a href="https://github.com/vanruby/vanruby.github.io/blob/master/_data/companies.csv">company list</a> and submit a Pull Request.</p>
 


### PR DESCRIPTION
@ericbrooke's last name is singular "Brooke", but currently has an extra "s" on the end