### PR TITLE
Add Meetup video and slide links

### DIFF
--- a/css/vanruby.css
+++ b/css/vanruby.css
@@ -20,6 +20,11 @@ body {
 .meetup-date {
   color: #9c9c9c;
   min-width: 8em;
+  vertical-align: top;
+}
+
+.meetup-details {
+  border-top: 2px solid #efefef;
 }
 
 .meetup-row {

--- a/css/vanruby.css
+++ b/css/vanruby.css
@@ -19,10 +19,15 @@ body {
 
 .meetup-date {
   color: #9c9c9c;
+  min-width: 8em;
 }
 
-.meetup-date-md {
-  display: inline-block;
-  width: 8em;
+.meetup-row {
+  border-bottom: 15px solid transparent;
 }
 
+@media (max-width: 768px) {
+  .xs-block {
+    display: block;
+  }
+}

--- a/js/application.js
+++ b/js/application.js
@@ -14,5 +14,11 @@
 
   $("a[data-toggle='tooltip']").tooltip();
 
+  $("a[data-expand]").click(function() {
+    var target = $(this).attr('data-expand')
+    var $target = $(target);
+    $target.toggleClass('hide');
+  });
+
 
 })(jQuery);

--- a/meetups.html
+++ b/meetups.html
@@ -13,12 +13,34 @@ title: "VanRuby - Past Meetups"
 <table class"table hover">
   <tbody>
     {% for meetup in meetups %}
+      {% assign num_slides = meetup.slides | size %}
+      {% assign num_videos = meetup.videos | size %}
+
       <tr class="meetup-row">
         <td class="meetup-date xs-block">{{ meetup.date | date: '%b %d, %Y' }}</td>
         <td class="xs-block">
-          <a href="{{ meetup.url }}">
-            {{ meetup.name }}
-          </a>
+          {% if num_slides > 0 or num_videos > 0 %}
+            <a href="javascript:void(0)" data-expand="#meetup-details-{{ forloop.index }}">
+              {{ meetup.name }}
+            </a>
+            <div id="meetup-details-{{ forloop.index }}" class="js-meetup-details meetup-details hide">
+              <ul>
+                <li><a href="{{ meetup.url }}" target="_blank">Event on Meetup.com</a></li>
+                {% for video in meetup.videos %}
+                  <li><a href="{{ video }}" target="_blank">Video</a></li>
+                {% endfor %}
+
+                {% for slide in meetup.slides %}
+                  <li><a href="{{ slide }}" target="_blank">Slides</a></li>
+                {% endfor %}
+              </ul>
+              </p>
+            </div>
+          {% else %}
+            <a href="{{ meetup.url }}">
+              {{ meetup.name }}
+            </a>
+          {% endif %}
         </td>
       </tr>
     {% endfor %}

--- a/meetups.html
+++ b/meetups.html
@@ -10,19 +10,18 @@ title: "VanRuby - Past Meetups"
 
 <hr />
 
-{% for meetup in meetups %}
-<div class="row meetups">
-  <div class="col-xs-12 visible-xs meetup-date">
-    <small>{{ meetup.date | date: '%b %d, %Y' }}</small>
-  </div>
-  <div class="col-xs-12" style="margin-bottom: 20px">
-    <h4>
-      <small class="hidden-xs meetup-date-md">{{ meetup.date | date: '%b %d, %Y' }}</small>
-      <a href="{{ meetup.url }}">
-        {{ meetup.name }}
-      </a>
-    </h4>
-  </div>
-</div>
-{% endfor %}
+<table class"table hover">
+  <tbody>
+    {% for meetup in meetups %}
+      <tr class="meetup-row">
+        <td class="meetup-date xs-block">{{ meetup.date | date: '%b %d, %Y' }}</td>
+        <td class="xs-block">
+          <a href="{{ meetup.url }}">
+            {{ meetup.name }}
+          </a>
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
 


### PR DESCRIPTION
Refactors the layout of the meetup page to add video and slide links, when present.

* If there are slides and/or videos, clicking the meetup title will expand to show all the links (including the meetup page).
* If there are no slides or videos, clicking the meetup title will open a new tab to the meetup page. 

**Screenshots 📷** 
<img width="1088" alt="screen shot 2018-10-21 at 10 28 52" src="https://user-images.githubusercontent.com/7259082/47270256-274ea200-d51e-11e8-830f-cf8625fb7ae2.png">

<img width="1093" alt="screen shot 2018-10-21 at 10 29 05" src="https://user-images.githubusercontent.com/7259082/47270258-2c135600-d51e-11e8-8f9b-09a8ff62c516.png">

<img width="391" alt="screen shot 2018-10-21 at 10 29 16" src="https://user-images.githubusercontent.com/7259082/47270259-2e75b000-d51e-11e8-82c7-9b4b50c2b19f.png">

<img width="389" alt="screen shot 2018-10-21 at 10 29 25" src="https://user-images.githubusercontent.com/7259082/47270260-3170a080-d51e-11e8-8351-f7af5a4379ef.png">
