### PR TITLE
Add link to Talks repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@ title: "VanRuby - Vancouver Ruby on Rails Group"
     <p>We get together once a month to talk about awesome things happening in the Ruby community. <a href="http://www.meetup.com/vancouver-ruby/">Join our meetup group</a>.</p>
   </div>
   <div class="col-md-4">
-    <h2><span class="glyphicon glyphicon-cog"></span> Dev Nights</h2>
-    <p><em>Now organized by <a href="http://www.meetup.com/PolyglotVancouver/">Polyglot Vancouver</a>. More details on their <a href="http://www.meetup.com/PolyglotVancouver/">Meetup page</a>.</em></p>
+    <h2><span class="glyphicon glyphicon-bullhorn"></span> Submit a Talk!</h2>
+    <p>Want to talk at an upcoming VanRuby? <a href="https://github.com/vanruby/talks">Check out our Talks repo</a> and submit a proposal. We welcome all backgrounds and levels of experience.
   </div>
   <div class="col-md-4">
     <h2><span class="glyphicon glyphicon-heart"></span> Cool People</h2>


### PR DESCRIPTION
Replaces the Dev Nights block with a blurb about the talks repo:

<img width="1175" alt="screen shot 2019-01-09 at 17 05 02" src="https://user-images.githubusercontent.com/7259082/50939211-c2c22580-1430-11e9-96f9-268557170b0d.png">
